### PR TITLE
Mitigate merkle tree collision by disallowing 64 byte transactions

### DIFF
--- a/btcrelay.se
+++ b/btcrelay.se
@@ -151,7 +151,9 @@ def storeBlockHeader(blockHeaderBytes:str):
 
 
 def verifyRawTx(txBytes:str, txIndex, sibling:arr, txBlockHash):
-    # todo: check if txBytes is 64 (is check 32 also needed?)
+    if len(txBytes) == 64:  # todo: is check 32 also needed?
+        # log ?
+        return(-1)
     txHash = m_dblShaFlip(txBytes)
     res = self.verifyTx(txHash, txIndex, sibling, txBlockHash, value=msg.value)
     return(res)

--- a/btcrelay.se
+++ b/btcrelay.se
@@ -196,8 +196,7 @@ def verifyTx(txHash:uint256, txIndex, sibling:arr, txBlockHash):
 # if the transaction does not pass verification, error code ERR_RELAY_VERIFY
 # is logged and returned
 def relayTx(txBytes:str, txIndex, sibling:arr, txBlockHash, contract):
-    txHash = m_dblShaFlip(txBytes)
-    if self.verifyTx(txHash, txIndex, sibling, txBlockHash, value=msg.value) == 1:
+    if self.verifyRawTx(txBytes, txIndex, sibling, txBlockHash, value=msg.value) == 1:
         returnCode = contract.processTransaction(txBytes, txHash)
         log(type=RelayTransaction, txHash, returnCode)
         return(returnCode)

--- a/btcrelay.se
+++ b/btcrelay.se
@@ -151,10 +151,10 @@ def storeBlockHeader(blockHeaderBytes:str):
 
 
 def verifyRawTx(txBytes:str, txIndex, sibling:arr, txBlockHash):
-    if len(txBytes) == 64:  # todo: is check 32 also needed?
-        # log ?
-        return(0:uint256)
     txHash = m_dblShaFlip(txBytes)
+    if len(txBytes) == 64:  # todo: is check 32 also needed?
+        log(type=VerifyTransaction, txHash, ERR_TX_64BYTE)
+        return(0:uint256)
     res = self.verifyTx(txHash, txIndex, sibling, txBlockHash, value=msg.value)
     if res == 1:
         return(txHash:uint256)
@@ -205,7 +205,6 @@ def relayTx(txBytes:str, txIndex, sibling:arr, txBlockHash, contract):
         log(type=RelayTransaction, txHash, returnCode)
         return(returnCode)
 
-    log(type=RelayTransaction, txBytes, ERR_RELAY_VERIFY)
     return(ERR_RELAY_VERIFY)
 
 

--- a/btcrelay.se
+++ b/btcrelay.se
@@ -159,6 +159,7 @@ def verifyRawTx(txBytes:str, txIndex, sibling:arr, txBlockHash):
     if res == 1:
         return(txHash:uint256)
     else:
+        # log is done via verifyTx
         return(0:uint256)
 
 
@@ -205,6 +206,7 @@ def relayTx(txBytes:str, txIndex, sibling:arr, txBlockHash, contract):
         log(type=RelayTransaction, txHash, returnCode)
         return(returnCode)
 
+    log(type=RelayTransaction, 0, ERR_RELAY_VERIFY)
     return(ERR_RELAY_VERIFY)
 
 

--- a/btcrelay.se
+++ b/btcrelay.se
@@ -150,6 +150,13 @@ def storeBlockHeader(blockHeaderBytes:str):
     return(0)
 
 
+def verifyRawTx(txBytes:str, txIndex, sibling:arr, txBlockHash):
+    # todo: check if txBytes is 64 (is check 32 also needed?)
+    txHash = m_dblShaFlip(txBytes)
+    res = self.verifyTx(txHash, txIndex, sibling, txBlockHash, value=msg.value)
+    return(res)
+
+
 # returns 1 if tx is in the block given by 'txBlockHash' and the block is
 # in Bitcoin's main chain (ie not a fork)
 #

--- a/btcrelay.se
+++ b/btcrelay.se
@@ -153,10 +153,13 @@ def storeBlockHeader(blockHeaderBytes:str):
 def verifyRawTx(txBytes:str, txIndex, sibling:arr, txBlockHash):
     if len(txBytes) == 64:  # todo: is check 32 also needed?
         # log ?
-        return(-1)
+        return(0:uint256)
     txHash = m_dblShaFlip(txBytes)
     res = self.verifyTx(txHash, txIndex, sibling, txBlockHash, value=msg.value)
-    return(res)
+    if res == 1:
+        return(txHash:uint256)
+    else:
+        return(0:uint256)
 
 
 # returns 1 if tx is in the block given by 'txBlockHash' and the block is
@@ -196,12 +199,13 @@ def verifyTx(txHash:uint256, txIndex, sibling:arr, txBlockHash):
 # if the transaction does not pass verification, error code ERR_RELAY_VERIFY
 # is logged and returned
 def relayTx(txBytes:str, txIndex, sibling:arr, txBlockHash, contract):
-    if self.verifyRawTx(txBytes, txIndex, sibling, txBlockHash, value=msg.value) == 1:
+    txHash = self.verifyRawTx(txBytes, txIndex, sibling, txBlockHash, value=msg.value)
+    if txHash != 0:
         returnCode = contract.processTransaction(txBytes, txHash)
         log(type=RelayTransaction, txHash, returnCode)
         return(returnCode)
 
-    log(type=RelayTransaction, txHash, ERR_RELAY_VERIFY)
+    log(type=RelayTransaction, txBytes, ERR_RELAY_VERIFY)
     return(ERR_RELAY_VERIFY)
 
 

--- a/constants.se
+++ b/constants.se
@@ -23,6 +23,7 @@ macro ERR_BAD_FEE: 20010
 macro ERR_CONFIRMATIONS: 20020
 macro ERR_CHAIN: 20030
 macro ERR_MERKLE_ROOT: 20040
+macro ERR_TX_64BYTE: 20050
 
 # error codes for relayTx
 macro ERR_RELAY_VERIFY: 30010

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -754,6 +754,17 @@ class TestBtcRelay(object):
         assert res['output'] == expMerkle
 
 
+        # internalHash is merkle hashing the first 2 txs in block 100K
+        # This proves that computeMerkle is helpless against internal hashes
+        internalHash = 0xccdafb73d8dcd0173d5d5c3c9a0770d0b3953db889dab99ef05b1907518cb815
+        txIndex = 0
+        sibling = [0x8e30899078ca1813be036a073bbf80b86cdddde1c96e9e9c99e9e3782df4ae49]
+
+        res = self.c.computeMerkle(internalHash, txIndex, sibling, profiling=True)
+        expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
+        assert res['output'] == expMerkle
+
+
     def testsetInitialParentOnlyOnce(self):
         assert self.c.setInitialParent(0, 0, 1) == 1
         assert self.c.setInitialParent(0, 0, 1) == 0

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -335,6 +335,10 @@ class TestBtcRelay(object):
         res = self.c.verifyRawTx(rawTx, txIndex, sibling, txBlockHash)
         assert res == 1
 
+        fakeRawTx = hex(txHash)[2:-1].decode('hex')[::-1] + hex(sibling[0])[2:-1].decode('hex')[::-1]
+        sibling = [sibling[1]]
+        res = self.c.verifyRawTx(fakeRawTx, txIndex, sibling, txBlockHash)
+        assert res == 1  # todo: this should be 0
 
 
     # TODO verify tx in b1

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -742,6 +742,16 @@ class TestBtcRelay(object):
         expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
         assert res['output'] == expMerkle
 
+        # internalHash is merkle hashing the first 2 txs in block 100K
+        # This proves that computeMerkle is helpless against internal hashes
+        internalHash = 0xccdafb73d8dcd0173d5d5c3c9a0770d0b3953db889dab99ef05b1907518cb815
+        txIndex = 0
+        sibling = [0x8e30899078ca1813be036a073bbf80b86cdddde1c96e9e9c99e9e3782df4ae49]
+
+        res = self.c.computeMerkle(internalHash, txIndex, sibling, profiling=True)
+        expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
+        assert res['output'] == expMerkle
+
 
         # values are from block 99997 (2 txs)
         txHash = 0xb86f5ef1da8ddbdb29ec269b535810ee61289eeac7bf2b2523b494551f03897c
@@ -751,17 +761,6 @@ class TestBtcRelay(object):
         res = self.c.computeMerkle(txHash, txIndex, sibling, profiling=True)
         print('GAS: '+str(res['gas']))
         expMerkle = 0x5140e5972f672bf8e81bc189894c55a410723b095716eaeec845490aed785f0e
-        assert res['output'] == expMerkle
-
-
-        # internalHash is merkle hashing the first 2 txs in block 100K
-        # This proves that computeMerkle is helpless against internal hashes
-        internalHash = 0xccdafb73d8dcd0173d5d5c3c9a0770d0b3953db889dab99ef05b1907518cb815
-        txIndex = 0
-        sibling = [0x8e30899078ca1813be036a073bbf80b86cdddde1c96e9e9c99e9e3782df4ae49]
-
-        res = self.c.computeMerkle(internalHash, txIndex, sibling, profiling=True)
-        expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
         assert res['output'] == expMerkle
 
 

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -353,9 +353,13 @@ class TestBtcRelay(object):
         assert eventArr == [{'_event_type': 'VerifyTransaction',
             'txHash': dblSha256Flip(fakeRawTx),
             'returnCode': self.ERR_TX_64BYTE
+            },
+            {'_event_type': 'RelayTransaction',
+            'txHash': 0,
+            'returnCode': self.ERR_RELAY_VERIFY
             }]
         eventArr.pop()
-
+        eventArr.pop()
 
 
     # TODO verify tx in b1

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -745,12 +745,9 @@ class TestBtcRelay(object):
         # internalHash is merkle hashing the first 2 txs in block 100K
         # This proves that computeMerkle is helpless against internal hashes
         internalHash = 0xccdafb73d8dcd0173d5d5c3c9a0770d0b3953db889dab99ef05b1907518cb815
-        txIndex = 0
-        sibling = [0x8e30899078ca1813be036a073bbf80b86cdddde1c96e9e9c99e9e3782df4ae49]
-
-        res = self.c.computeMerkle(internalHash, txIndex, sibling, profiling=True)
-        expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
-        assert res['output'] == expMerkle
+        sibling = [ sibling[1] ]
+        res = self.c.computeMerkle(internalHash, txIndex, sibling)
+        assert res == expMerkle
 
 
         # values are from block 99997 (2 txs)

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -338,7 +338,7 @@ class TestBtcRelay(object):
         fakeRawTx = hex(txHash)[2:-1].decode('hex')[::-1] + hex(sibling[0])[2:-1].decode('hex')[::-1]
         sibling = [sibling[1]]
         res = self.c.verifyRawTx(fakeRawTx, txIndex, sibling, txBlockHash)
-        assert res == 1  # todo: this should be 0
+        assert res == -1
 
 
     # TODO verify tx in b1

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -20,6 +20,8 @@ class TestBtcRelay(object):
     ERR_PROOF_OF_WORK = 10090
     ERR_CONFIRMATIONS = 20020
     ERR_CHAIN = 20030
+    ERR_RELAY_VERIFY = 30010
+
 
     def setup_class(cls):
         tester.gas_limit = int(2.7e6)  # include costs of debug methods
@@ -339,6 +341,9 @@ class TestBtcRelay(object):
         sibling = [sibling[1]]
         res = self.c.verifyRawTx(fakeRawTx, txIndex, sibling, txBlockHash)
         assert res == -1
+
+        res = self.c.relayTx(fakeRawTx, txIndex, sibling, txBlockHash, 0)  # contract address is irrelevant
+        assert res == self.ERR_RELAY_VERIFY
 
 
     # TODO verify tx in b1

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -20,6 +20,7 @@ class TestBtcRelay(object):
     ERR_PROOF_OF_WORK = 10090
     ERR_CONFIRMATIONS = 20020
     ERR_CHAIN = 20030
+    ERR_TX_64BYTE = 20050
     ERR_RELAY_VERIFY = 30010
 
 
@@ -349,9 +350,9 @@ class TestBtcRelay(object):
         res = self.c.relayTx(fakeRawTx, txIndex, sibling, txBlockHash, 0)  # contract address is irrelevant
         assert res == self.ERR_RELAY_VERIFY
 
-        assert eventArr == [{'_event_type': 'RelayTransaction',
-            'txHash': fakeRawTx,
-            'returnCode': self.ERR_RELAY_VERIFY
+        assert eventArr == [{'_event_type': 'VerifyTransaction',
+            'txHash': dblSha256Flip(fakeRawTx),
+            'returnCode': self.ERR_TX_64BYTE
             }]
         eventArr.pop()
 

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -22,7 +22,7 @@ class TestBtcRelay(object):
     ERR_CHAIN = 20030
 
     def setup_class(cls):
-        tester.gas_limit = int(2.6e6)  # include costs of debug methods
+        tester.gas_limit = int(2.7e6)  # include costs of debug methods
         cls.s = tester.state()
         cls.c = cls.s.abi_contract(cls.CONTRACT_DEBUG)
         cls.snapshot = cls.s.snapshot()
@@ -287,6 +287,54 @@ class TestBtcRelay(object):
         blockHeaderStr = ("03000000f9dd57bd9e5cfdfb77550a9358cbba47eb823684f43362080000000000000000d1eaebbc3dbb07d59c0f4b69afb99518e0e4fc6512c1cd3495b3b6ebcbac27a3cf8e1f56140f1218aca005b1")
         bhBytes = blockHeaderStr.decode('hex')
         assert self.c.storeBlockHeader(bhBytes) == blockDivisibleBy2016
+
+
+    # based on testHeadersFrom100K
+    def testVerifyRawTx(self):
+        block100kPrev = 0x000000000002d01c1fccc21636b607dfd930d31d01c3a62104612a1719011250
+        self.c.setInitialParent(block100kPrev, 99999, 1)
+
+        headers = [
+            "0100000050120119172a610421a6c3011dd330d9df07b63616c2cc1f1cd00200000000006657a9252aacd5c0b2940996ecff952228c3067cc38d4885efb5a4ac4247e9f337221b4d4c86041b0f2b5710",
+            "0100000006e533fd1ada86391f3f6c343204b0d278d4aaec1c0b20aa27ba0300000000006abbb3eb3d733a9fe18967fd7d4c117e4ccbbac5bec4d910d900b3ae0793e77f54241b4d4c86041b4089cc9b",
+            "0100000090f0a9f110702f808219ebea1173056042a714bad51b916cb6800000000000005275289558f51c9966699404ae2294730c3c9f9bda53523ce50e9b95e558da2fdb261b4d4c86041b1ab1bf93",
+            "01000000aff7e0c7dc29d227480c2aa79521419640a161023b51cdb28a3b0100000000003779fc09d638c4c6da0840c41fa625a90b72b125015fd0273f706d61f3be175faa271b4d4c86041b142dca82",
+            "01000000e1c5ba3a6817d53738409f5e7229ffd098d481147b002941a7a002000000000077ed2af87aa4f9f450f8dbd15284720c3fd96f565a13c9de42a3c1440b7fc6a50e281b4d4c86041b08aecda2",
+            "0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d63",
+            "0100000045dc58743362fe8d8898a7506faa816baed7d391c9bc0b13b0da00000000000021728a2f4f975cc801cb3c672747f1ead8a946b2702b7bd52f7b86dd1aa0c975c02a1b4d4c86041b7b47546d"
+        ]
+        blockHeaderBytes = map(lambda x: x.decode('hex'), headers)
+        for i in range(7):
+            res = self.c.storeBlockHeader(blockHeaderBytes[i])
+            # print('@@@@ real chain score: ' + str(self.c.getCumulativeDifficulty()))
+            assert res == i+100000
+
+        cumulDiff = self.c.getCumulativeDifficulty()
+
+        # block hashes
+        b0 = 0x000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506
+        b1 = 0x00000000000080b66c911bd5ba14a74260057311eaeb1982802f7010f1a9f090 # block #100001
+        b2 = 0x0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af
+        b3 = 0x000000000002a0a74129007b1481d498d0ff29725e9f403837d517683abac5e1
+        b4 = 0x000000000000b0b8b4e8105d62300d63c8ec1a1df0af1c2cdbd943b156a8cd79
+        b5 = 0x000000000000dab0130bbcc991d3d7ae6b81aa6f50a798888dfe62337458dc45
+        b6 = 0x0000000000009b958a82c10804bd667722799cc3b457bc061cd4b7779110cd60
+
+        # values are from block 100K
+        rawTx = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84ac00000000'.decode('hex')
+        txHash = 0x8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87
+        assert dblSha256Flip(rawTx) == txHash
+        txIndex = 0
+        sibling = [None] * 2
+        sibling[0] = 0xfff2525b8931402dd09222c50775608f75787bd2b87e56995a7bdd30f79702c4
+        sibling[1] = 0x8e30899078ca1813be036a073bbf80b86cdddde1c96e9e9c99e9e3782df4ae49
+
+
+        # verifyTx should only return 1 for b0
+        txBlockHash = b0
+        res = self.c.verifyRawTx(rawTx, txIndex, sibling, txBlockHash)
+        assert res == 1
+
 
 
     # TODO verify tx in b1

--- a/test/test_btcrelay.py
+++ b/test/test_btcrelay.py
@@ -730,7 +730,7 @@ class TestBtcRelay(object):
 
 
     def testComputeMerkle(self):
-        # values are from block 100K
+        # values are from block 100K (4 txs)
         txHash = 0x8c14f0db3df150123e6f3dbbf30f8b955a8249b62ac1d1ff16284aefa3d06d87
         txIndex = 0
         sibling = [None] * 2
@@ -741,6 +741,18 @@ class TestBtcRelay(object):
         print('GAS: '+str(res['gas']))
         expMerkle = 0xf3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766
         assert res['output'] == expMerkle
+
+
+        # values are from block 99997 (2 txs)
+        txHash = 0xb86f5ef1da8ddbdb29ec269b535810ee61289eeac7bf2b2523b494551f03897c
+        txIndex = 0
+        sibling = [0x80c6f121c3e9fe0a59177e49874d8c703cbadee0700a782e4002e87d862373c6]
+
+        res = self.c.computeMerkle(txHash, txIndex, sibling, profiling=True)
+        print('GAS: '+str(res['gas']))
+        expMerkle = 0x5140e5972f672bf8e81bc189894c55a410723b095716eaeec845490aed785f0e
+        assert res['output'] == expMerkle
+
 
     def testsetInitialParentOnlyOnce(self):
         assert self.c.setInitialParent(0, 0, 1) == 1

--- a/test/test_txVerify.py
+++ b/test/test_txVerify.py
@@ -302,7 +302,7 @@ class TestTxVerify(object):
                         'returnCode': self.ERR_CONFIRMATIONS
                     },
                     {'_event_type': 'RelayTransaction',
-                    'txHash': txHash,
+                    'txHash': 0,
                     'returnCode': self.ERR_RELAY_VERIFY
                     }]
                 eventArr.pop()


### PR DESCRIPTION
verifyTx and relayTx were validating a hash that was not an actual txHash, but an "internal" hash of the merkle tree.  To prevent this, transactions exactly 64 bytes will not be validated.  verifyRawTx has been introduced and renames will be done in a subsequent commit.