### PR TITLE
Modify break statement of nTime loop

### DIFF
--- a/fetchd/fetchd.py
+++ b/fetchd/fetchd.py
@@ -199,14 +199,17 @@ def run(feeVerifyTx, feeRecipient, doFetch=False, network=BITCOIN_TESTNET, start
                 else:
                     logger.info('@@@@ handle orphan did not succeed iteration {0}'.format(i))
                     break  # start the refetch again, this time ++i
-        break  # chainHead is same realHead
+        
+        # chainHead is same realHead
+        if chainHead == realHead:
+            break
 
     actualHeight = last_block_height(network)  # pybitcointools 1.1.33
 
     if startBlock:
         instance.heightToStartFetch = startBlock
     else:
-        instance.heightToStartFetch = getLastBlockHeight() + 1
+        instance.heightToStartFetch = heightToRefetch + 1
 
     logger.info('@@@ startFetch: {0} actualHeight: {1}'.format(instance.heightToStartFetch, actualHeight))
 


### PR DESCRIPTION
I think this break prevents the loop from starting the refetch again, because the statement always breaks the loop.
And also instance.heightToStartFetch = getLastBlockHeight() + 1 should be changed to instance.heightToStartFetch = heightToRefetch + 1